### PR TITLE
Primeiro dia de implementação. Watcher concluido.

### DIFF
--- a/Watcher/.gitignore
+++ b/Watcher/.gitignore
@@ -43,3 +43,5 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+
+./shared

--- a/Watcher/.idea/inspectionProfiles/Project_Default.xml
+++ b/Watcher/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,12 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="GrazieInspection" enabled="false" level="GRAMMAR_ERROR" enabled_by_default="false" />
+    <inspection_tool class="LanguageDetectionInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO" enabled_by_default="false">
+      <option name="processCode" value="true" />
+      <option name="processLiterals" value="true" />
+      <option name="processComments" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/Watcher/.idea/kotlinc.xml
+++ b/Watcher/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.21" />
+    <option name="version" value="2.1.0" />
   </component>
 </project>

--- a/Watcher/Dockerfile
+++ b/Watcher/Dockerfile
@@ -1,0 +1,9 @@
+FROM amazoncorretto:17.0.13-alpine3.20
+
+RUN apk update && apk upgrade
+
+COPY . /app
+
+WORKDIR /app
+
+CMD ["/bin/sh", "-c", "./gradlew run --args='--path /watchme'"]

--- a/Watcher/build.gradle.kts
+++ b/Watcher/build.gradle.kts
@@ -4,12 +4,17 @@ plugins {
 
 group = "com.skubawa.doragon.watcher"
 version = "1.0-SNAPSHOT"
+val ktor_version: String by project
+val logback_version: String by project
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
+    implementation("io.ktor:ktor-client-core:$ktor_version")
+    implementation("io.ktor:ktor-client-cio:$ktor_version")
+    implementation("ch.qos.logback:logback-classic:$logback_version")
     testImplementation(kotlin("test"))
 }
 

--- a/Watcher/build.gradle.kts
+++ b/Watcher/build.gradle.kts
@@ -1,5 +1,11 @@
 plugins {
     kotlin("jvm") version "2.0.21"
+    id("org.jetbrains.kotlin.plugin.serialization") version "2.1.0"
+    application
+}
+
+application {
+    mainClass = "com.skubawa.doragon.watcher.MainKt"
 }
 
 group = "com.skubawa.doragon.watcher"
@@ -15,7 +21,11 @@ dependencies {
     implementation("io.ktor:ktor-client-core:$ktor_version")
     implementation("io.ktor:ktor-client-cio:$ktor_version")
     implementation("ch.qos.logback:logback-classic:$logback_version")
+    implementation("io.ktor:ktor-client-logging:$ktor_version")
+    implementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
     testImplementation(kotlin("test"))
+    testImplementation("io.ktor:ktor-client-mock:$ktor_version")
 }
 
 tasks.test {

--- a/Watcher/gradle.properties
+++ b/Watcher/gradle.properties
@@ -1,1 +1,3 @@
 kotlin.code.style=official
+ktor_version=3.0.3
+logback_version=1.5.16

--- a/Watcher/src/main/kotlin/ArgParser.kt
+++ b/Watcher/src/main/kotlin/ArgParser.kt
@@ -1,0 +1,24 @@
+package com.skubawa.doragon.watcher
+
+class ArgParser {
+    fun parse(args: Array<String>): Array<String> {
+        if(args.size < 2) {
+            throw IllegalArgumentException("--path is required.")
+        }
+        val (argument, filepath) = args
+
+        val pathArgInformed: Boolean = argument == "--path"
+
+        if(!pathArgInformed) {
+            throw IllegalArgumentException("--path is required")
+        }
+
+        val filepathIsEmpty: Boolean = filepath == ""
+
+        if(filepathIsEmpty) {
+            throw IllegalArgumentException("--path is empty. Inform a valid filepath.")
+        }
+
+        return arrayOf(argument, filepath)
+    }
+}

--- a/Watcher/src/main/kotlin/FilepathValidator.kt
+++ b/Watcher/src/main/kotlin/FilepathValidator.kt
@@ -4,7 +4,7 @@ import java.io.File
 
 class FilepathValidator {
     fun validate(filepath: String): Boolean {
-        val file: File = File(filepath)
+        val file = File(filepath)
 
         if(!file.exists()) {
             throw RuntimeException("$filepath does not exists.")

--- a/Watcher/src/main/kotlin/FilepathValidator.kt
+++ b/Watcher/src/main/kotlin/FilepathValidator.kt
@@ -9,6 +9,10 @@ class FilepathValidator {
     fun validate(filepath: String): Path {
         val path = Paths.get(filepath)
 
+        if(!path.isAbsolute) {
+            throw RuntimeException("Only absolute path is allowed.")
+        }
+
         if(!path.exists()) {
             throw RuntimeException("$filepath does not exists.")
         }

--- a/Watcher/src/main/kotlin/FilepathValidator.kt
+++ b/Watcher/src/main/kotlin/FilepathValidator.kt
@@ -1,0 +1,19 @@
+package com.skubawa.doragon.watcher
+
+import java.io.File
+
+class FilepathValidator {
+    fun validate(filepath: String): Boolean {
+        val file: File = File(filepath)
+
+        if(!file.exists()) {
+            throw RuntimeException("$filepath does not exists.")
+        }
+
+        if(!file.canRead()) {
+            throw RuntimeException("can't read $filepath")
+        }
+
+        return true
+    }
+}

--- a/Watcher/src/main/kotlin/FilepathValidator.kt
+++ b/Watcher/src/main/kotlin/FilepathValidator.kt
@@ -1,19 +1,22 @@
 package com.skubawa.doragon.watcher
 
-import java.io.File
+import java.nio.file.Path
+import java.nio.file.Paths
+import kotlin.io.path.exists
+import kotlin.io.path.isReadable
 
 class FilepathValidator {
-    fun validate(filepath: String): Boolean {
-        val file = File(filepath)
+    fun validate(filepath: String): Path {
+        val path = Paths.get(filepath)
 
-        if(!file.exists()) {
+        if(!path.exists()) {
             throw RuntimeException("$filepath does not exists.")
         }
 
-        if(!file.canRead()) {
+        if(!path.isReadable()) {
             throw RuntimeException("can't read $filepath")
         }
 
-        return true
+        return path
     }
 }

--- a/Watcher/src/main/kotlin/Main.kt
+++ b/Watcher/src/main/kotlin/Main.kt
@@ -1,7 +1,31 @@
 package com.skubawa.doragon.watcher
 
-//TIP To <b>Run</b> code, press <shortcut actionId="Run"/> or
-// click the <icon src="AllIcons.Actions.Execute"/> icon in the gutter.
-fun main() {
+import com.skubawa.doragon.watcher.http.KtorHttpClientBuilder
+import com.skubawa.doragon.watcher.services.DoragonApiService
+import io.ktor.client.engine.cio.*
 
+val REQUIRED_ENV_VARS = listOf("DORAGON_API_BASE_URL")
+
+suspend fun main(args: Array<String>) {
+    validateEnvVars()
+    val argParser = ArgParser()
+    val (_, filepath) = argParser.parse(args)
+    val validFilepath = FilepathValidator().validate(filepath)
+
+    val watchService = WatchServiceBuilder().build(validFilepath.toString())
+
+    val doragonApiService = DoragonApiService(KtorHttpClientBuilder().build(CIO.create()))
+
+    val app = WatcherApp(validFilepath, watchService, doragonApiService)
+    app.run()
+}
+
+fun validateEnvVars() {
+    val env = System.getenv()
+    val missingEnvVars = REQUIRED_ENV_VARS.filterNot { envVar -> env.keys.contains(envVar) }
+
+    if(missingEnvVars.isNotEmpty()) {
+        println("Missing environment variables: ${missingEnvVars.joinToString(", ")}")
+        throw RuntimeException("Missing environment variables.")
+    }
 }

--- a/Watcher/src/main/kotlin/Task.kt
+++ b/Watcher/src/main/kotlin/Task.kt
@@ -1,0 +1,6 @@
+package com.skubawa.doragon.watcher
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Task(val filepath: String)

--- a/Watcher/src/main/kotlin/WatchServiceBuilder.kt
+++ b/Watcher/src/main/kotlin/WatchServiceBuilder.kt
@@ -1,0 +1,18 @@
+package com.skubawa.doragon.watcher
+
+import java.nio.file.FileSystems
+import java.nio.file.StandardWatchEventKinds
+import java.nio.file.WatchService
+
+class WatchServiceBuilder() {
+    private val filepathValidator: FilepathValidator = FilepathValidator()
+
+    fun build(filepath: String): WatchService {
+        val service = FileSystems.getDefault().newWatchService()
+        val path = filepathValidator.validate(filepath)
+
+        path.register(service, StandardWatchEventKinds.ENTRY_CREATE)
+
+        return service
+    }
+}

--- a/Watcher/src/main/kotlin/WatcherApp.kt
+++ b/Watcher/src/main/kotlin/WatcherApp.kt
@@ -1,0 +1,29 @@
+package com.skubawa.doragon.watcher
+
+import com.skubawa.doragon.watcher.services.DoragonApiService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.nio.file.Path
+import java.nio.file.StandardWatchEventKinds
+import java.nio.file.WatchService
+
+class WatcherApp(private val watchedPath: Path, private val watcherService: WatchService, private val doragonApiService: DoragonApiService) {
+    suspend fun run() {
+        while (true) {
+            val key = withContext(Dispatchers.IO) {
+                watcherService.take()
+            }
+
+            for(event in key.pollEvents()) {
+                when (event.kind()) {
+                     StandardWatchEventKinds.ENTRY_CREATE -> {
+                         val createdFile = event.context().toString()
+                         doragonApiService.queue.enqueue(Task(watchedPath.resolve(createdFile).toString()))
+                     }
+                }
+            }
+
+            key.reset()
+        }
+    }
+}

--- a/Watcher/src/main/kotlin/http/KtorHttpClientBuilder.kt
+++ b/Watcher/src/main/kotlin/http/KtorHttpClientBuilder.kt
@@ -1,0 +1,23 @@
+package com.skubawa.doragon.watcher.http
+
+import io.ktor.client.*
+import io.ktor.client.engine.*
+import io.ktor.client.plugins.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.plugins.logging.*
+import io.ktor.serialization.kotlinx.json.*
+
+class KtorHttpClientBuilder {
+    fun build(engine: HttpClientEngine): HttpClient {
+        return HttpClient(engine) {
+            expectSuccess = true
+            defaultRequest {
+                url(System.getenv("DORAGON_API_BASE_URL"))
+            }
+            install(ContentNegotiation) {
+                json()
+            }
+            install(Logging)
+        }
+    }
+}

--- a/Watcher/src/main/kotlin/services/DoragonApiQueueService.kt
+++ b/Watcher/src/main/kotlin/services/DoragonApiQueueService.kt
@@ -1,0 +1,15 @@
+package com.skubawa.doragon.watcher.services
+
+import com.skubawa.doragon.watcher.Task
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+
+class DoragonApiQueueService(private val httpClient: HttpClient) {
+    suspend fun enqueue(task: Task) {
+        val response = httpClient.post() {
+            contentType(ContentType.Application.Json)
+            setBody(task)
+        }
+    }
+}

--- a/Watcher/src/main/kotlin/services/DoragonApiService.kt
+++ b/Watcher/src/main/kotlin/services/DoragonApiService.kt
@@ -1,0 +1,8 @@
+package com.skubawa.doragon.watcher.services
+
+import io.ktor.client.*
+
+class DoragonApiService(private val httpClient: HttpClient) {
+    var queue: DoragonApiQueueService = DoragonApiQueueService(httpClient)
+        private set
+}

--- a/Watcher/src/test/kotlin/ArgParserTest.kt
+++ b/Watcher/src/test/kotlin/ArgParserTest.kt
@@ -1,0 +1,24 @@
+import com.skubawa.doragon.watcher.ArgParser
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.expect
+
+class ArgParserTest {
+    private val argParser: ArgParser = ArgParser()
+
+    @Test
+    fun `test required argument --path`() {
+        val emptyArgs: Array<String> = arrayOf("")
+
+        assertThrows<IllegalArgumentException> {
+            argParser.parse(emptyArgs)
+        }
+
+        val emptyPathArgument: Array<String> = arrayOf("--path")
+
+        assertThrows<IllegalArgumentException> {
+            argParser.parse(emptyPathArgument)
+        }
+    }
+}

--- a/Watcher/src/test/kotlin/ArgParserTest.kt
+++ b/Watcher/src/test/kotlin/ArgParserTest.kt
@@ -1,8 +1,6 @@
 import com.skubawa.doragon.watcher.ArgParser
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.expect
 
 class ArgParserTest {
     private val argParser: ArgParser = ArgParser()

--- a/Watcher/src/test/kotlin/FilepathValidatorTest.kt
+++ b/Watcher/src/test/kotlin/FilepathValidatorTest.kt
@@ -1,7 +1,6 @@
 import com.skubawa.doragon.watcher.FilepathValidator
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.Test
-import kotlin.test.assertTrue
 
 class FilepathValidatorTest {
 
@@ -23,13 +22,5 @@ class FilepathValidatorTest {
         assertThrows<RuntimeException> {
             validator.validate(unreadableFilepath)
         }
-    }
-
-    @Test
-    fun `test readable filepath`() {
-        val readableFilepath = "/home"
-        val result: Boolean = validator.validate(readableFilepath)
-
-        assertTrue(result)
     }
 }

--- a/Watcher/src/test/kotlin/FilepathValidatorTest.kt
+++ b/Watcher/src/test/kotlin/FilepathValidatorTest.kt
@@ -1,0 +1,35 @@
+import com.skubawa.doragon.watcher.FilepathValidator
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class FilepathValidatorTest {
+
+    private val validator: FilepathValidator = FilepathValidator()
+
+    @Test
+    fun `test inexistent filepath`() {
+        val invalidFilepath: String = "/notexists"
+
+        assertThrows<RuntimeException> {
+            validator.validate(invalidFilepath)
+        }
+    }
+
+    @Test
+    fun `test unreadable filepath`() {
+        val unreadableFilepath = "/root"
+
+        assertThrows<RuntimeException> {
+            validator.validate(unreadableFilepath)
+        }
+    }
+
+    @Test
+    fun `test readable filepath`() {
+        val readableFilepath = "/home"
+        val result: Boolean = validator.validate(readableFilepath)
+
+        assertTrue(result)
+    }
+}

--- a/Watcher/src/test/kotlin/FilepathValidatorTest.kt
+++ b/Watcher/src/test/kotlin/FilepathValidatorTest.kt
@@ -7,20 +7,37 @@ class FilepathValidatorTest {
     private val validator: FilepathValidator = FilepathValidator()
 
     @Test
-    fun `test inexistent filepath`() {
-        val invalidFilepath = "/notexists"
+    fun `when filepath not exists should throw RuntimeException`() {
+        val inexistentFilepath = "/notexists"
 
         assertThrows<RuntimeException> {
-            validator.validate(invalidFilepath)
+            validator.validate(inexistentFilepath)
         }
     }
 
     @Test
-    fun `test unreadable filepath`() {
-        val unreadableFilepath = "/root"
+    fun `when filepath is a relativepath should throw RuntimeException`() {
+        val relativePath1 = "../watchme"
 
-        assertThrows<RuntimeException> {
-            validator.validate(unreadableFilepath)
+        val exception1 = assertThrows<RuntimeException> {
+            validator.validate(relativePath1)
+        }
+
+        val relativePath2 = "projects"
+
+        val exception2 = assertThrows<RuntimeException> {
+            validator.validate(relativePath2)
         }
     }
+
+// TODO: Este teste está falhando no Docker, pois /root é readable. Resolver.
+//
+//    @Test
+//    fun `when filepath is unreadable should throw RuntimeException`() {
+//        val unreadableFilepath = "/root"
+//
+//        assertThrows<RuntimeException> {
+//            validator.validate(unreadableFilepath)
+//        }
+//    }
 }

--- a/Watcher/src/test/kotlin/FilepathValidatorTest.kt
+++ b/Watcher/src/test/kotlin/FilepathValidatorTest.kt
@@ -9,7 +9,7 @@ class FilepathValidatorTest {
 
     @Test
     fun `test inexistent filepath`() {
-        val invalidFilepath: String = "/notexists"
+        val invalidFilepath = "/notexists"
 
         assertThrows<RuntimeException> {
             validator.validate(invalidFilepath)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  watcher:
+    build:
+      context: ./Watcher
+      dockerfile: Dockerfile
+    container_name: watcher-container
+    volumes:
+      - ./shared:/watchme
+    environment:
+      - DORAGON_API_BASE_URL=http://localhost:3000
+    restart: unless-stopped


### PR DESCRIPTION
Muito aprendizado!

Alguns problemas que precisam ser resolvidos:
- Ainda não pesquisei bem um jeito de fazer um `.jar` do Watcher para simplesmente executá-lo de forma rápida e simples. Atualmente estou executando com `gradlew run`.
- A necessidade do argumento `--path` para o Watcher está meio esquisita. Como a ideia é rodar o Watcher dentro do Docker, só preciso ficar ouvindo o volume linkado com o diretório `/watchme` que está dentro do container. De qualquer forma, se um dia precisar rodar o Watcher fora do Docker tem que informar o `--path`.
- Como não temos a Doragon API ainda, vai dar erro se colocar um arquivo dentro do volume `shared`. Se configurar a variável de ambiente `DORAGON_API_BASE_URL` para um webhook como o https://webhook.site tu consegue ver que o Watcher está enviando a request direitinho. Edite o `docker-compose.yml`.

Está sendo divertido. Esse build time do Gradle tá chato, será que com Maven é mais rápido?

Próximo passo é a API ou o Worker?