### PR TITLE
Implementação da API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/rabbitmq
+/shared

--- a/Api/build.gradle.kts
+++ b/Api/build.gradle.kts
@@ -24,6 +24,8 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
+	implementation("com.rabbitmq:amqp-client:5.24.0")
+	implementation ("org.postgresql:postgresql:42.6.0")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/Api/src/main/kotlin/com/skubawa/doragon/api/Config.kt
+++ b/Api/src/main/kotlin/com/skubawa/doragon/api/Config.kt
@@ -1,0 +1,16 @@
+package com.skubawa.doragon.api
+
+import com.rabbitmq.client.Connection
+import com.rabbitmq.client.ConnectionFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class Config {
+    @Bean(destroyMethod = "close")
+    fun createConnection(): Connection {
+        val factory = ConnectionFactory()
+
+        return factory.newConnection()
+    }
+}

--- a/Api/src/main/kotlin/com/skubawa/doragon/api/entities/UserFile.kt
+++ b/Api/src/main/kotlin/com/skubawa/doragon/api/entities/UserFile.kt
@@ -1,0 +1,13 @@
+package com.skubawa.doragon.api.entities
+
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import java.util.UUID
+
+@Entity
+class UserFile {
+    @Id
+    val id: UUID = UUID.randomUUID()
+    val bucketName: String = String()
+    val objectId: String = String()
+}

--- a/Api/src/main/kotlin/com/skubawa/doragon/api/http/queue/EnqueueRequestBody.kt
+++ b/Api/src/main/kotlin/com/skubawa/doragon/api/http/queue/EnqueueRequestBody.kt
@@ -1,0 +1,3 @@
+package com.skubawa.doragon.api.http.queue
+
+data class EnqueueRequestBody(val filepath: String)

--- a/Api/src/main/kotlin/com/skubawa/doragon/api/http/queue/QueuesController.kt
+++ b/Api/src/main/kotlin/com/skubawa/doragon/api/http/queue/QueuesController.kt
@@ -1,0 +1,34 @@
+package com.skubawa.doragon.api.http.queue
+
+import com.rabbitmq.client.Connection
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class QueuesController {
+    @Autowired()
+    lateinit var connection: Connection
+
+    @PostMapping("/enqueue")
+    fun enqueue(@RequestBody requestBody: EnqueueRequestBody) {
+        val channel = connection.createChannel()
+        val queueName = "doragon_tasks"
+        val isDurable = true
+        val isExclusive = false
+        val shouldAutoDelete = false
+        val exchangeName = "doragon_tasks_exchange"
+        val routingKey = queueName
+
+        channel.exchangeDeclare(exchangeName, "direct", true)
+        channel.queueDeclare(queueName, isDurable, isExclusive, shouldAutoDelete, null)
+
+        channel.queueBind(queueName, exchangeName, routingKey)
+
+        val body = requestBody.toString().toByteArray()
+
+        channel.basicPublish(exchangeName, routingKey, null, body)
+        channel.close()
+    }
+}

--- a/Api/src/main/resources/application.properties
+++ b/Api/src/main/resources/application.properties
@@ -1,1 +1,17 @@
 spring.application.name=api
+spring.datasource.url=jdbc:${DATABASE_URL}
+spring.datasource.username=${DATABASE_USERNAME}
+spring.datasource.password=${DATABASE_PASSWORD}
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.rabbitmq.host=localhost
+spring.rabbitmq.port=5672
+spring.rabbitmq.username=guest
+spring.rabbitmq.password=guest
+spring.rabbitmq.virtual-host=/
+spring.rabbitmq.connection-timeout=10000
+spring.rabbitmq.requested-heartbeat=60
+spring.rabbitmq.publisher-confirms=true
+spring.rabbitmq.publisher-returns=true

--- a/Watcher/src/main/kotlin/services/DoragonApiQueueService.kt
+++ b/Watcher/src/main/kotlin/services/DoragonApiQueueService.kt
@@ -7,7 +7,7 @@ import io.ktor.http.*
 
 class DoragonApiQueueService(private val httpClient: HttpClient) {
     suspend fun enqueue(task: Task) {
-        val response = httpClient.post() {
+        val response = httpClient.post("/enqueue") {
             contentType(ContentType.Application.Json)
             setBody(task)
         }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,5 +7,30 @@ services:
     volumes:
       - ./shared:/watchme
     environment:
-      - DORAGON_API_BASE_URL=http://localhost:3000
+      - DORAGON_API_BASE_URL=http://localhost:8080
     restart: unless-stopped
+    network_mode: "host"
+  database:
+    container_name: database-container
+    image: postgres
+    restart: always
+    shm_size: 128mb
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: doragon
+    ports:
+      - "5432:5432"
+    depends_on:
+      - rabbitmq
+  rabbitmq:
+    image: rabbitmq:4.0.5-management
+    container_name: rabbitmq-container
+    ports:
+      - "15672:15672"
+      - "5672:5672"
+    environment:
+      - RABBITMQ_DEFAULT_USER=guest
+      - RABBITMQ_DEFAULT_PASS=guest
+    volumes:
+      - ./rabbitmq:/var/lib/rabbitmq


### PR DESCRIPTION
Essa é a implementação inicial da API.

Resolvido um bug no Watcher onde a classe que faz a request para a API não estava com a URL configurada adequadamente.

Coloquei o `network_mode` para o watcher no docker-compose.yml senão ele não conseguia acessar a API rodando em localhost no host. Isso provavelmente mudará no futuro uma vez que a intenção é todas as partes da Doragon rodar via docker-compose, então basta compartilhar a mesma network entre todos os containers.

Implementado `/enqueue` para receber requisições do Watcher para enfileirar Tasks para os Workers fazerem o upload no Minio. A rota ainda não está recebendo adequadamente os dados da Task para enviar para o RabbitMQ, mas já está enfileirando "qualquer coisa" lá.

Só bora :)

